### PR TITLE
Make metadata keys lower case for processing

### DIFF
--- a/pelican_pandoc_reader/__init__.py
+++ b/pelican_pandoc_reader/__init__.py
@@ -91,9 +91,10 @@ class PandocReader(BaseReader):
             extra_args=['--template', self.METADATA_TEMPLATE]
         )
 
-        _metadata = json.loads(metadata_json)
         metadata = dict()
-        for key, value in _metadata.items():
+        for key, value in json.loads(metadata_json).items():
+            # Make key lower case to match processor definitions.
+            key = key.lower()
             metadata[key] = self.process_metadata(key, value)
 
         return metadata


### PR DESCRIPTION
Pelican uses lower case names to decide if the keys are special.  Lower
case the field names to allow e.g. 'Date' as well as 'date' in the
document metadata.