### PR TITLE
Change default non-Pandoc markdown flavor

### DIFF
--- a/pelican_pandoc_reader/__init__.py
+++ b/pelican_pandoc_reader/__init__.py
@@ -14,8 +14,8 @@ import pypandoc
 logger = logging.getLogger(__name__)
 
 pandoc_fmt_map = {
-    'md': 'commonmark+yaml_metadata_block',
-    'pdc': 'markdown'
+    'md': 'markdown_mmd',  # Multi-Markdown
+    'pdc': 'markdown'  # Pandoc Markdown
 }
 
 pelican_url_directive = re.compile(


### PR DESCRIPTION
With my Pandoc (2.6), I can't get `commonmark+yaml_metadata_block` to
pick up the metadata, with or without `---` YaML markers around the
metadata block.

From the manual, I don't think the `yaml_metadata_block` extension works
with `commonmark`:

http://pandoc.org/MANUAL.html#markdown-variants

In any case, it seems to me that most people will expect Markdown
similar to Pelican's default, so, using Markdown title blocks, without
the YaML markers.

Here I changed the default to Multi-Markdown, that does allow these
header blocks, by default.