### PR TITLE
Fix author key

### DIFF
--- a/pelican_pandoc_reader/__init__.py
+++ b/pelican_pandoc_reader/__init__.py
@@ -94,8 +94,9 @@ class PandocReader(BaseReader):
         _metadata = json.loads(metadata_json)
         metadata = dict()
         for key, value in _metadata.items():
+            if key == 'author' and isinstance(value, list):
+                key = 'authors'
             metadata[key] = self.process_metadata(key, value)
-
         return metadata
 
     def process_settings(self):


### PR DESCRIPTION
When writing a pandoc header such as

% A Title
% Author Name

Author Name will be passed as `'author': ['Author Name']`. Subsequent processing
steps in pelican expect author to be a single string, so we just make it
`'authors'` instead, which appears to work fine.