### PR TITLE
Update use of Pelican signals

### DIFF
--- a/src/pelican_pandoc_reader/__init__.py
+++ b/src/pelican_pandoc_reader/__init__.py
@@ -1,5 +1,5 @@
 import pelican.readers
-import pelican.signals
+from pelican import signals
 import pelican.utils
 
 import os
@@ -80,7 +80,7 @@ class PandocReader(pelican.readers.BaseReader):
                 fpath = f.name
             PandocReader.METADATA_TEMPLATE = fpath
             logger.debug("Metadata template file at '%s'", fpath)
-            pelican.signals.finalized.connect(PandocReader.delete_metadata_template)
+            signals.finalized.connect(PandocReader.delete_metadata_template)
 
     @staticmethod
     def delete_metadata_template(pelican_obj):
@@ -152,4 +152,4 @@ def add_reader(readers):
 
 def register():
     logger.debug("Registering pelican_pandoc_reader plugin.")
-    pelican.signals.readers_init.connect(add_reader)
+    signals.readers_init.connect(add_reader)


### PR DESCRIPTION
Before this change, a current Pelican build fails with:

```
ERROR: Cannot load plugin `pelican_pandoc_reader`
  | Importing from `pelican.signals` is deprecated. Use `from pelican import signals` or `import pelican.plugins.signals` instead.
```